### PR TITLE
`View::update` takes a `Cow<'_, Update>` instead of a `&Update`

### DIFF
--- a/games/tic_tac_toe/src/public_info.rs
+++ b/games/tic_tac_toe/src/public_info.rs
@@ -1,6 +1,7 @@
 use crate::{Position, TicTacToe};
 use lttcore::{Player, View};
 use serde::{Deserialize, Serialize};
+use std::borrow::Cow;
 use std::ops::Deref;
 
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, Serialize, Deserialize)]
@@ -29,8 +30,8 @@ pub enum PublicInfoUpdate {
 impl View for PublicInfo {
     type Update = PublicInfoUpdate;
 
-    fn update(&mut self, update: &Self::Update) {
-        match update {
+    fn update(&mut self, update: Cow<'_, Self::Update>) {
+        match update.as_ref() {
             PublicInfoUpdate::Resign(player) => {
                 self.0.resign(*player);
             }

--- a/lttcore/src/examples/guess_the_number.rs
+++ b/lttcore/src/examples/guess_the_number.rs
@@ -5,6 +5,7 @@ use crate::{
 };
 use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::ops::RangeInclusive;
 use thiserror::Error;
@@ -115,8 +116,8 @@ impl From<PublicInfoUpdate> for PublicInfo {
 impl View for PublicInfo {
     type Update = PublicInfoUpdate;
 
-    fn update(&mut self, update: &Self::Update) {
-        let _ = std::mem::replace(self, update.clone().into());
+    fn update(&mut self, update: Cow<'_, Self::Update>) {
+        let _ = std::mem::replace(self, update.into_owned().into());
     }
 }
 

--- a/lttcore/src/view.rs
+++ b/lttcore/src/view.rs
@@ -1,11 +1,12 @@
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use std::borrow::Cow;
 
 use std::fmt::Debug;
 
 pub trait View: Clone + Debug + PartialEq + Eq + Serialize + DeserializeOwned {
     type Update: Clone + Debug + PartialEq + Eq + Serialize + DeserializeOwned;
 
-    fn update(&mut self, _update: &Self::Update) {}
+    fn update(&mut self, _update: Cow<'_, Self::Update>) {}
 }
 
 #[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]


### PR DESCRIPTION
This allows the runtime to provide an owned value if possible and a
borrowed value if not. The implementation of update can decide if
cloning is required, so we don't have to clone if the value will go
unused.

This goes especially nicely with the fact that the updates will need to
go over the wire so having an owned variant is really nice because the remote
will likely have an owned value it's willing to give to the view. It also means that
`GamePlayers`'s co-located with the `GameProgression` can just borrow what
they need