### PR TITLE
Make `game_type` be passed as a `String` in the network protocol

### DIFF
--- a/lttcore/src/encoder.rs
+++ b/lttcore/src/encoder.rs
@@ -25,6 +25,7 @@ pub mod bincode {
         fn serialize<T: Serialize>(value: &T) -> Result<Bytes, Self::Error> {
             bincode::serialize(value).map(|vec| vec.into())
         }
+
         fn deserialize<T: DeserializeOwned>(bytes: Bytes) -> Result<T, Self::Error> {
             bincode::deserialize(&bytes)
         }

--- a/lttnetworking/src/client/client_connection.rs
+++ b/lttnetworking/src/client/client_connection.rs
@@ -1,75 +1,82 @@
-use crate::connection::{ConnectionIO, RawConnection, SubConnection, SubConnectionId};
+use crate::connection::{ConnectionIO, RawConnection, SubConnId, SubConnection};
 use crate::messages::closed::Closed;
 use crate::messages::conn_ctrl::{
     ClientConnControlMsg as CCCMsg, ServerConnControlMsg as SCCMsg, SubConnMode,
 };
 use crate::messages::hello::{ClientHello, ServerHello, ServerInfo};
-use crate::{SupportedGames, Token, User};
+use crate::{Token, User};
+use async_trait::async_trait;
 use bytes::Bytes;
 use lttcore::encoder::Encoder;
 use std::collections::HashMap;
 use tokio::select;
 use tokio::sync::mpsc;
 
-pub async fn client_connection<S: SupportedGames<E>, E: Encoder>(
+#[async_trait]
+pub trait Job<E: Encoder> {
+    async fn run(self, sub_conn: SubConnection<E>);
+    fn game_type(&self) -> &'static str;
+    fn sub_conn_mode(&self) -> SubConnMode;
+}
+
+struct State<E: Encoder> {
+    pending: HashMap<SubConnId, Box<dyn Job<E>>>,
+    running: HashMap<SubConnId, mpsc::UnboundedSender<Bytes>>,
+}
+
+pub async fn client_connection<E: Encoder>(
     credentials: Token,
-    mut jobs: impl Iterator<Item = (S, SubConnMode, Box<dyn FnOnce(SubConnection<E>)>)>,
-    concurrency: u64,
+    max_concurrency: u8,
+    mut jobs: impl Iterator<Item = Box<dyn Job<E>>>,
     mut conn: impl RawConnection<E>,
 ) -> Result<Closed, Closed> {
     let (_user, server_info) = authenticate_conn(credentials, &mut conn).await?;
-    let concurrency: usize = server_info
-        .max_sub_connections
-        .min(concurrency)
-        .try_into()
-        .unwrap();
+    let concurrency: usize = server_info.max_sub_connections.min(max_concurrency).into();
+    let mut state: State<E> = State {
+        pending: HashMap::new(),
+        running: HashMap::new(),
+    };
 
     let (from_sub_connections_sender, mut from_sub_connections_receiver) =
-        mpsc::unbounded_channel::<(SubConnectionId, Bytes)>();
+        mpsc::unbounded_channel::<(SubConnId, Bytes)>();
 
-    let mut pending_jobs: HashMap<
-        SubConnectionId,
-        (SubConnMode, Box<dyn FnOnce(SubConnection<E>)>),
-    > = Default::default();
-    let mut running_jobs: HashMap<SubConnectionId, mpsc::UnboundedSender<Bytes>> =
-        Default::default();
-
-    for (game_type, sub_conn_mode, fun) in jobs.take(concurrency) {
-        let id = SubConnectionId::new();
-        let msg: CCCMsg<S, E> = CCCMsg::StartSubConn {
-            id,
-            game_type,
-            _encoder: Default::default(),
-        };
-        conn.send(msg).await?;
-        pending_jobs.insert(id, (sub_conn_mode, fun));
+    for _ in 0..concurrency {
+        if let Some(job) = jobs.next() {
+            let id = SubConnId::new();
+            conn.send(CCCMsg::StartSubConn {
+                id,
+                game_type: job.game_type().to_string(),
+            })
+            .await?;
+            state.pending.insert(id, job);
+        }
     }
 
     loop {
         select! {
             biased;
-            msg = conn.next::<SCCMsg<S, E>>() => {
+            msg = conn.next::<SCCMsg>() => {
                 match msg? {
                     SCCMsg::SubConnStarted { id, .. } => {
-                        let (sub_conn_mode, fun) = pending_jobs
+                        let job = state.pending
                             .remove(&id)
-                            .expect("server only sends us already pending jobs");
+                            .expect("server only sends us pending jobs");
 
                         let (sender, receiver) = mpsc::unbounded_channel();
 
-                        let mut sub_conn = SubConnection {
+                        let mut sub_conn: SubConnection<E> = SubConnection {
                             id,
                             receiver,
                             sender: Some(from_sub_connections_sender.clone()),
                             _encoder: Default::default()
                         };
 
-                        sub_conn.send(sub_conn_mode).await?;
-                        running_jobs.insert(id, sender);
-                        fun(sub_conn);
+                        sub_conn.send(job.sub_conn_mode()).await?;
+                        state.running.insert(id, sender);
+                        // tokio::spawn(async { fun(sub_conn) });
                     }
-                    SCCMsg::SubConnMsg { id, bytes, .. } => {
-                        match running_jobs.get(&id).map(|sender| sender.send(bytes)) {
+                    SCCMsg::SubConnMsg { id, bytes } => {
+                        match state.running.get(&id).map(|sender| sender.send(bytes)) {
                             Some(Ok(())) => continue,
                             Some(Err(_)) => {
                                 todo!("job failed")
@@ -80,27 +87,22 @@ pub async fn client_connection<S: SupportedGames<E>, E: Encoder>(
 
                         }
                     }
-                    SCCMsg::SubConnClosed { id, .. } => {
-                        pending_jobs.remove(&id);
+                    SCCMsg::SubConnClosed { id, reason: _ } => {
+                        state.pending.remove(&id);
+                        state.running.remove(&id);
 
-                        if let Some((game_type, sub_conn_mode, fun)) = jobs.pop() {
-                            let id = SubConnectionId::new();
-                            let msg: CCCMsg<S, E> = CCCMsg::StartSubConn { id, game_type, _encoder: Default::default() };
-                            conn.send(msg).await?;
-                            pending_jobs.insert(id, (sub_conn_mode, fun));
-                        }
-
-                        if jobs.is_empty() && pending_jobs.is_empty() && running_jobs.is_empty() {
-                            conn.close().await;
+                        if let Some(job) = jobs.next() {
+                            let id = SubConnId::new();
+                            conn.send(CCCMsg::StartSubConn { id, game_type: job.game_type().to_string() }).await?;
+                            state.pending.insert(id, job);
+                        } else if state.pending.is_empty() && state.running.is_empty() {
                             return Ok(Closed::Normal)
                         }
-
                     }
                 }
             }
             Some((id, bytes)) = from_sub_connections_receiver.recv() => {
-                let msg: CCCMsg<S, E> = CCCMsg::SubConnMsg { id, bytes, _encoder: Default::default() };
-                conn.send(msg).await?;
+                conn.send(CCCMsg::SubConnMsg { id, bytes }).await?;
             }
         }
     }
@@ -110,8 +112,7 @@ pub async fn authenticate_conn<E: Encoder>(
     credentials: Token,
     conn: &mut impl ConnectionIO<E>,
 ) -> Result<(User, ServerInfo), Closed> {
-    let client_hello = ClientHello { credentials };
-    conn.send(client_hello).await?;
+    conn.send(ClientHello { credentials }).await?;
     let ServerHello { user, server_info } = conn.next::<Result<ServerHello, Closed>>().await??;
     Ok((user, server_info))
 }

--- a/lttnetworking/src/example_supported_games.rs
+++ b/lttnetworking/src/example_supported_games.rs
@@ -11,6 +11,11 @@ use std::collections::HashMap;
 use std::fmt::Debug;
 use std::sync::Arc;
 
+/// This will eventually be the output from a macro
+/// Something like `supported_games!(GuessTheNumber, TicTacToe)` or
+/// `supported_games!(./path/to/config.toml)`, I'm writing it out by hand here to figure out how
+/// the macro should work
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum ExampleSupportedGames<E: Encoder> {
     GuessTheNumber(std::marker::PhantomData<E>),
@@ -60,6 +65,13 @@ impl<E: Encoder> SupportedGames<E> for ExampleSupportedGames<E> {
                 let runtime = runtimes.get_guess_the_number_run_time();
                 run_server_sub_conn::<GuessTheNumber, E, C>(conn, runtime).await
             }
+        }
+    }
+
+    fn try_from_str(s: &str) -> Option<Self> {
+        match s {
+            "GuessTheNumber" => Some(ExampleSupportedGames::GuessTheNumber(Default::default())),
+            _ => None,
         }
     }
 }

--- a/lttnetworking/src/messages/closed.rs
+++ b/lttnetworking/src/messages/closed.rs
@@ -8,5 +8,6 @@ pub enum Closed {
     Unauthorized,
     InvalidCredentials,
     ServerError,
+    Unsupported(String),
     ClientError(String),
 }

--- a/lttnetworking/src/messages/conn_ctrl.rs
+++ b/lttnetworking/src/messages/conn_ctrl.rs
@@ -1,50 +1,21 @@
-use crate::connection::SubConnectionId;
+use crate::connection::SubConnId;
 use crate::messages::closed::Closed;
-use crate::SupportedGames;
 use bytes::Bytes;
-use lttcore::encoder::Encoder;
 use lttcore::id::GameId;
 use lttcore::Player;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[serde(bound = "")]
-pub enum ClientConnControlMsg<S: SupportedGames<E>, E: Encoder> {
-    StartSubConn {
-        id: SubConnectionId,
-        game_type: S,
-        #[serde(skip)]
-        _encoder: std::marker::PhantomData<E>,
-    },
-    SubConnMsg {
-        id: SubConnectionId,
-        bytes: Bytes,
-        #[serde(skip)]
-        _encoder: std::marker::PhantomData<E>,
-    },
+pub enum ClientConnControlMsg {
+    StartSubConn { id: SubConnId, game_type: String },
+    SubConnMsg { id: SubConnId, bytes: Bytes },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[serde(bound = "")]
-pub enum ServerConnControlMsg<S: SupportedGames<E>, E: Encoder> {
-    SubConnStarted {
-        id: SubConnectionId,
-        game_type: S,
-        #[serde(skip)]
-        _encoder: std::marker::PhantomData<E>,
-    },
-    SubConnMsg {
-        id: SubConnectionId,
-        bytes: Bytes,
-        #[serde(skip)]
-        _encoder: std::marker::PhantomData<E>,
-    },
-    SubConnClosed {
-        id: SubConnectionId,
-        reason: Closed,
-        #[serde(skip)]
-        _encoder: std::marker::PhantomData<E>,
-    },
+pub enum ServerConnControlMsg {
+    SubConnStarted { id: SubConnId },
+    SubConnMsg { id: SubConnId, bytes: Bytes },
+    SubConnClosed { id: SubConnId, reason: Closed },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]

--- a/lttnetworking/src/messages/hello.rs
+++ b/lttnetworking/src/messages/hello.rs
@@ -14,5 +14,5 @@ pub struct ServerHello {
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ServerInfo {
-    pub max_sub_connections: u64,
+    pub max_sub_connections: u8,
 }

--- a/lttnetworking/src/supported_games.rs
+++ b/lttnetworking/src/supported_games.rs
@@ -18,4 +18,6 @@ pub trait SupportedGames<E: Encoder>:
         conn: C,
         runtimes: Arc<Self::Runtimes>,
     ) -> Result<(), Closed>;
+
+    fn try_from_str(s: &str) -> Option<Self>;
 }


### PR DESCRIPTION
This simplifies the types greatly because it means that none of the
control messages need to know about \`SupportedGames\` or \`Encoder\`.
It's a big goal to make the client not have to use the
`supported_games!` macro that the server is going to need to use. I'd
like people to be able to pull a crate off the shelf and have it "just
work" in their clients.

Just in general the goal should be for amount of work

ltti interactive players/watchers << AI builders << Game Implementers <<
Server Operators << Grant