### PR TITLE
Tic Tac Toe Interface improvements

### DIFF
--- a/lttcore/src/bots/bot.rs
+++ b/lttcore/src/bots/bot.rs
@@ -1,6 +1,5 @@
 use crate::pov::PlayerPov;
 use crate::{GameProgression, Play};
-use std::error::Error;
 
 pub trait Bot {
     type Game: Play;
@@ -8,7 +7,7 @@ pub trait Bot {
     fn run(
         player_pov: &PlayerPov<'_, Self::Game>,
         rng: &mut impl rand::Rng,
-    ) -> Result<<Self::Game as Play>::Action, Box<dyn Error>>;
+    ) -> <Self::Game as Play>::Action;
 }
 
 pub trait OmniscientBot {
@@ -17,5 +16,5 @@ pub trait OmniscientBot {
     fn run(
         game_progression: &GameProgression<Self::Game>,
         rng: &mut impl rand::Rng,
-    ) -> Result<<Self::Game as Play>::Action, Box<dyn Error>>;
+    ) -> <Self::Game as Play>::Action;
 }

--- a/lttcore/src/examples/tic_tac_toe/board.rs
+++ b/lttcore/src/examples/tic_tac_toe/board.rs
@@ -1,4 +1,347 @@
+use super::Marker;
+use crate::Player;
+use itertools::iproduct;
 use serde::{Deserialize, Serialize};
+use std::cmp::Ordering;
+use std::ops::{Index, IndexMut};
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum Status {
+    /// There are still available positions to be claimed on the board
+    InProgress { next_up: Marker },
+    /// All positions have been claimed and there is no winner
+    Draw,
+    /// Win by resignation
+    WinByResignation { winner: Marker },
+    /// There *is* a winner via connecting three spaces
+    Win {
+        winner: Marker,
+        positions: [Position; 3],
+    },
+}
+
+impl Status {
+    pub fn winner(&self) -> Option<Marker> {
+        match self {
+            Status::Win { winner, .. } | Status::WinByResignation { winner, .. } => Some(*winner),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct Board([[Option<Marker>; 3]; 3]);
+
+impl From<[[Option<Marker>; 3]; 3]> for Board {
+    fn from(markers: [[Option<Marker>; 3]; 3]) -> Self {
+        Self(markers)
+    }
+}
+
+impl Board {
+    pub fn rows(&self) -> impl Iterator<Item = [Option<Marker>; 3]> + '_ {
+        ROWS.into_iter()
+            .map(|row| COLS.map(|col| (self[(col, row)].clone())))
+    }
+
+    pub fn cols(&self) -> impl Iterator<Item = [Option<Marker>; 3]> + '_ {
+        COLS.into_iter()
+            .map(|col| ROWS.map(|row| (self[(col, row)].clone())))
+    }
+
+    pub fn diagonals(&self) -> impl Iterator<Item = [Option<Marker>; 3]> + '_ {
+        [
+            [(COL_0, ROW_0), (COL_1, ROW_1), (COL_2, ROW_2)],
+            [(COL_0, ROW_2), (COL_1, ROW_1), (COL_2, ROW_0)],
+        ]
+        .into_iter()
+        .map(|group| group.map(|pos| self[pos].clone()))
+    }
+
+    /// Iterate over the spaces on the board and the marker in the space (if there is one)
+    ///
+    /// ```
+    /// use lttcore::ttt;
+    /// use lttcore::examples::tic_tac_toe::{Row, Col, Marker::*, Position};
+    ///
+    /// let board = ttt!([
+    ///   X O X
+    ///   - - -
+    ///   - X O
+    /// ]);
+    /// assert_eq!(
+    ///   board.spaces().collect::<Vec<_>>(),
+    ///   vec![
+    ///     ((Col::new(0), Row::new(0)), None),
+    ///     ((Col::new(0), Row::new(1)), None),
+    ///     ((Col::new(0), Row::new(2)), Some(X)),
+    ///     ((Col::new(1), Row::new(0)), Some(X)),
+    ///     ((Col::new(1), Row::new(1)), None),
+    ///     ((Col::new(1), Row::new(2)), Some(O)),
+    ///     ((Col::new(2), Row::new(0)), Some(O)),
+    ///     ((Col::new(2), Row::new(1)), None),
+    ///     ((Col::new(2), Row::new(2)), Some(X))
+    ///   ]
+    /// );
+    /// ```
+    pub fn spaces(&self) -> impl Iterator<Item = (Position, Option<Marker>)> + '_ {
+        iproduct!(COLS, ROWS).map(|position: Position| (position, self[position].clone()))
+    }
+
+    /// Iterate over the spaces on the board that are taken
+    ///
+    /// ```
+    /// use lttcore::ttt;
+    /// use lttcore::examples::tic_tac_toe::{Row, Col, Marker::*};
+    ///
+    /// let board = ttt!([
+    ///   X O X
+    ///   - - -
+    ///   - X O
+    /// ]);
+    /// assert_eq!(
+    ///   board.taken_spaces().collect::<Vec<_>>(),
+    ///   vec![
+    ///     ((Col::new(0), Row::new(2)), X),
+    ///     ((Col::new(1), Row::new(0)), X),
+    ///     ((Col::new(1), Row::new(2)), O),
+    ///     ((Col::new(2), Row::new(0)), O),
+    ///     ((Col::new(2), Row::new(2)), X)
+    ///   ]
+    /// );
+    pub fn taken_spaces(&self) -> impl Iterator<Item = (Position, Marker)> + '_ {
+        self.spaces()
+            .flat_map(|(position, maybe_marker)| maybe_marker.map(|marker| (position, marker)))
+    }
+
+    /// Iterator over the empty spaces on the board
+    ///
+    /// ```
+    /// use lttcore::ttt;
+    /// use lttcore::examples::tic_tac_toe::{Board, Row, Col, Marker::*, Position};
+    ///
+    /// let board: Board = Default::default();
+    /// assert_eq!(board.empty_spaces().count(), 9);
+    ///
+    /// let board = ttt!([
+    ///   X X X
+    ///   X X X
+    ///   X X X
+    /// ]);
+    /// assert_eq!(board.empty_spaces().count(), 0);
+    ///
+    /// let board = ttt!([
+    ///   X O X
+    ///   - - -
+    ///   - X O
+    /// ]);
+    /// assert_eq!(board.empty_spaces().count(), 4);
+    /// assert_eq!(
+    ///   board.empty_spaces().collect::<Vec<_>>(),
+    ///   vec![
+    ///    (Col::new(0), Row::new(0)),
+    ///    (Col::new(0), Row::new(1)),
+    ///    (Col::new(1), Row::new(1)),
+    ///    (Col::new(2), Row::new(1))
+    ///   ]
+    /// );
+    /// ```
+    pub fn empty_spaces(&self) -> impl Iterator<Item = Position> + '_ {
+        self.spaces().filter_map(|(pos, player)| match player {
+            None => Some(pos),
+            Some(_) => None,
+        })
+    }
+
+    /// Returns a marker at a position, if the row or col is greater than 2, this returns None
+    ///
+    /// ```
+    /// use lttcore::ttt;
+    /// use lttcore::examples::tic_tac_toe::{Row, Col, Marker::*};
+    ///
+    /// let board = ttt!([
+    ///   X - -
+    ///   - - -
+    ///   - X O
+    /// ]);
+    /// assert_eq!(board.at((2, 0)), Some(O));
+    /// assert_eq!(board.at((0, 2)), Some(X));
+    /// assert_eq!(board.at((1, 0)), Some(X));
+    /// assert_eq!(board.at((0, 0)), None);
+    ///
+    /// // Out of bounds numbers return None
+    /// assert_eq!(board.at((0, 1000)), None);
+    /// assert_eq!(board.at((1000, 0)), None);
+    /// ```
+    pub fn at(&self, (c, r): (usize, usize)) -> Option<Marker> {
+        let col = Col::try_new(c)?;
+        let row = Row::try_new(r)?;
+
+        self[(col, row)]
+    }
+
+    /// Return the marker who's turn it is
+    ///
+    /// ```
+    /// use lttcore::ttt;
+    /// use lttcore::examples::tic_tac_toe::{Board, Marker::*};
+    ///
+    /// // Starts with X
+    /// let board: Board = Default::default();
+    /// assert_eq!(board.whose_turn(), X);
+
+    /// // Once the first player goes, it's the second player's turn
+    /// let board = ttt!([
+    ///   - - -
+    ///   - - -
+    ///   X - -
+    /// ]);
+    /// assert_eq!(board.whose_turn(), O);
+
+    /// // Once O goes, it's X's turn again
+    /// let board = ttt!([
+    ///   - - -
+    ///   - - -
+    ///   X O -
+    /// ]);
+    /// assert_eq!(board.whose_turn(), X);
+
+    /// // The next player to go is always the one with the fewest spaces
+    /// let board = ttt!([
+    ///   O O O
+    ///   O O O
+    ///   - O O
+    /// ]);
+    /// assert_eq!(board.whose_turn(), X);
+    /// ```
+    pub fn whose_turn(&self) -> Marker {
+        let mut counts = [0, 0];
+
+        for (_, marker) in self.taken_spaces() {
+            counts[usize::from(Player::from(marker))] += 1;
+        }
+
+        let [xs, os] = counts;
+        match xs.cmp(&os) {
+            Ordering::Greater => Marker::O,
+            Ordering::Equal => Marker::X,
+            Ordering::Less => Marker::X,
+        }
+    }
+
+    /// is the board full?
+    ///
+    /// ```
+    /// use lttcore::ttt;
+    ///
+    /// let board = ttt!([
+    ///   X X X
+    ///   X - X
+    ///   X X X
+    /// ]);
+    ///
+    /// assert!(board.has_open_spaces());
+    ///
+    /// let board = ttt!([
+    ///   X X X
+    ///   X X X
+    ///   X X X
+    /// ]);
+    ///
+    /// assert!(!board.has_open_spaces());
+    /// ```
+    pub fn has_open_spaces(&self) -> bool {
+        self.taken_spaces().count() < 9
+    }
+
+    /// Returns the status of the current game
+    /// ```
+    /// use lttcore::{Play, Player};
+    /// use lttcore::ttt;
+    /// use lttcore::examples::tic_tac_toe::{Board, Row, Col, Status::*, Marker::*};
+    ///
+    /// // In progress
+    /// let board: Board = Default::default();
+    /// assert_eq!(board.status(), InProgress{ next_up: X });
+    ///
+    /// // A draw
+    /// let board = ttt!([
+    ///   O X O
+    ///   X X O
+    ///   X O X
+    /// ]);
+    /// assert_eq!(board.status(), Draw);
+    ///
+    /// // With a winning position
+    /// let board = ttt!([
+    ///   - - -
+    ///   - - -
+    ///   X X X
+    /// ]);
+    ///
+    /// assert_eq!(
+    ///   board.status(),
+    ///   Win {
+    ///     winner: X,
+    ///     positions: [
+    ///       (Col::new(0), Row::new(0)),
+    ///       (Col::new(1), Row::new(0)),
+    ///       (Col::new(2), Row::new(0))
+    ///     ]
+    ///   }
+    /// );
+    /// ```
+    pub fn status(&self) -> Status {
+        POSSIBLE_WINS
+            .iter()
+            .find_map(|&positions| {
+                let [a, b, c] = positions.map(|pos| self[pos]);
+
+                if a == b && b == c {
+                    a.map(|winner| Status::Win { winner, positions })
+                } else {
+                    None
+                }
+            })
+            .unwrap_or_else(|| {
+                if self.has_open_spaces() {
+                    Status::InProgress {
+                        next_up: self.whose_turn(),
+                    }
+                } else {
+                    Status::Draw
+                }
+            })
+    }
+}
+
+impl Index<Position> for Board {
+    type Output = Option<Marker>;
+
+    fn index(&self, (col, row): Position) -> &Self::Output {
+        &self[row][usize::from(col)]
+    }
+}
+
+impl IndexMut<Position> for Board {
+    fn index_mut(&mut self, (col, row): Position) -> &mut Self::Output {
+        &mut self[row][usize::from(col)]
+    }
+}
+
+impl Index<Row> for Board {
+    type Output = [Option<Marker>; 3];
+
+    fn index(&self, row: Row) -> &Self::Output {
+        &self.0[usize::from(row)]
+    }
+}
+
+impl IndexMut<Row> for Board {
+    fn index_mut(&mut self, row: Row) -> &mut Self::Output {
+        &mut self.0[usize::from(row)]
+    }
+}
 
 macro_rules! board_index {
     ($id:ident) => {
@@ -116,6 +459,17 @@ impl BoardIndex {
 
 pub type Position = (Col, Row);
 use BoardIndex as BI;
+
+pub const ROW_0: Row = Row(BI(0));
+pub const ROW_1: Row = Row(BI(1));
+pub const ROW_2: Row = Row(BI(2));
+
+pub const ROWS: [Row; 3] = [ROW_0, ROW_1, ROW_2];
+pub const COLS: [Col; 3] = [COL_0, COL_1, COL_2];
+
+pub const COL_0: Col = Col(BI(0));
+pub const COL_1: Col = Col(BI(1));
+pub const COL_2: Col = Col(BI(2));
 
 pub const POSSIBLE_WINS: [[(Col, Row); 3]; 8] = [
     // Fill up a row

--- a/lttcore/src/examples/tic_tac_toe/bot.rs
+++ b/lttcore/src/examples/tic_tac_toe/bot.rs
@@ -1,0 +1,25 @@
+use super::{Action, Board, Marker, Position, TicTacToe};
+use crate::bots::Bot;
+use crate::pov::PlayerPov;
+use crate::Play;
+
+pub trait TicTacToeBot {
+    fn claim_space(marker: Marker, board: &Board, rng: &mut impl rand::Rng) -> Position;
+}
+
+#[derive(Debug)]
+pub struct TicTacToeBotWrapper<T: TicTacToeBot>(pub T);
+
+impl<T: TicTacToeBot> Bot for TicTacToeBotWrapper<T> {
+    type Game = TicTacToe;
+
+    fn run(
+        player_pov: &PlayerPov<'_, Self::Game>,
+        rng: &mut impl rand::Rng,
+    ) -> <Self::Game as Play>::Action {
+        let marker = Marker::try_from(player_pov.player).expect("is a valid player for TicTacToe");
+        let position = T::claim_space(marker, player_pov.public_info.board(), rng);
+
+        Action { position }
+    }
+}

--- a/lttcore/src/examples/tic_tac_toe/helpers.rs
+++ b/lttcore/src/examples/tic_tac_toe/helpers.rs
@@ -1,6 +1,4 @@
-use crate::Player;
-
-/// Helper function to have tic tac toe game literals
+/// Helper function to have `tic_tac_toe::Board` literals
 ///
 /// ## Notes
 ///
@@ -11,21 +9,23 @@ use crate::Player;
 /// use lttcore::ttt;
 /// use lttcore::examples::tic_tac_toe::Marker::*;
 ///
-/// let game = ttt!([
-///   X O -
-///   O O -
+/// let board = ttt!([
+///   - O -
+///   - O -
 ///   X - X
 /// ]);
 ///
-/// assert_eq!(game.at((0, 0)).unwrap(), X);
-/// assert_eq!(game.at((1, 1)).unwrap(), O);
-/// assert_eq!(game.at((2, 2)), None);
-/// assert!(game.resigned().is_empty());
+/// assert_eq!(board.at((0, 0)), Some(X));
+/// assert_eq!(board.at((1, 1)), Some(O));
+/// assert_eq!(board.at((1, 2)), Some(O));
+/// assert_eq!(board.at((0, 2)), None);
+/// assert_eq!(board.at((2, 0)), Some(X));
+/// assert_eq!(board.at((2, 2)), None);
 /// ```
 #[macro_export]
 macro_rules! ttt {
     ([ $a:tt $b:tt $c:tt $d:tt $e:tt $f:tt $g:tt $h:tt $i:tt ]) => {
-        $crate::examples::TicTacToe::from_markers([
+        $crate::examples::tic_tac_toe::Board::from([
             [ttt!(@$g), ttt!(@$h), ttt!(@$i)],
             [ttt!(@$d), ttt!(@$e), ttt!(@$f)],
             [ttt!(@$a), ttt!(@$b), ttt!(@$c)],
@@ -39,40 +39,4 @@ macro_rules! ttt {
     ($_:tt) => {
         compile_error!("ttt! only accepts exactly nine of either X, O, -")
     };
-}
-
-/// Returns the opponent of a player in `TicTacToe`
-///
-/// ```
-/// use lttcore::Player;
-/// use lttcore::ttt;
-/// use lttcore::examples::tic_tac_toe::{Marker::*, helpers::opponent};
-///
-/// let p0: Player = 0.into();
-/// let p1: Player = 1.into();
-///
-/// assert_eq!(opponent(p0), p1);
-/// assert_eq!(opponent(p1), p0);
-/// assert_eq!(opponent(X), p1);
-/// assert_eq!(opponent(O), p0);
-/// ```
-///
-/// # Panics
-///
-/// This panics with a player not in [0, 1]
-///
-/// ```should_panic
-/// use lttcore::Player;
-/// use lttcore::examples::tic_tac_toe::helpers::opponent;
-///
-/// let p3: Player = 3.into();
-/// opponent(p3);
-/// ```
-pub fn opponent(player: impl Into<Player>) -> Player {
-    let player = player.into();
-    match u8::from(player) {
-        0 => 1.into(),
-        1 => 0.into(),
-        _ => panic!("Invalid Player for TicTacToe"),
-    }
 }

--- a/lttcore/src/examples/tic_tac_toe/marker.rs
+++ b/lttcore/src/examples/tic_tac_toe/marker.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 use crate::Player;
 
 /// Conveniences for Player 0 and Player 1
@@ -15,10 +17,19 @@ use crate::Player;
 /// assert_eq!(p0, X);
 /// assert_eq!(p1, O);
 /// ```
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, Serialize, Deserialize)]
 pub enum Marker {
     X,
     O,
+}
+
+impl Marker {
+    pub fn opponent(&self) -> Self {
+        match self {
+            Marker::X => Marker::O,
+            Marker::O => Marker::X,
+        }
+    }
 }
 
 impl PartialEq<Marker> for Player {
@@ -32,6 +43,18 @@ impl PartialEq<Player> for Marker {
     fn eq(&self, &other: &Player) -> bool {
         let p: Player = (*self).into();
         other == p
+    }
+}
+
+impl TryFrom<Player> for Marker {
+    type Error = &'static str;
+
+    fn try_from(player: Player) -> Result<Self, Self::Error> {
+        match u8::from(player) {
+            0 => Ok(Marker::X),
+            1 => Ok(Marker::O),
+            _ => Err("Only players 0 or 1 can play `TicTacToe`"),
+        }
     }
 }
 

--- a/lttcore/src/examples/tic_tac_toe/mod.rs
+++ b/lttcore/src/examples/tic_tac_toe/mod.rs
@@ -1,5 +1,6 @@
 mod action;
 pub mod board;
+mod bot;
 pub mod helpers;
 mod marker;
 mod public_info;
@@ -7,6 +8,7 @@ mod settings;
 
 pub use action::{Action, ActionError};
 pub use board::{Board, BoardIndex, Col, Position, Row, Status, POSSIBLE_WINS};
+pub use bot::{TicTacToeBot, TicTacToeBotWrapper};
 pub use marker::Marker;
 pub use public_info::{PublicInfo, PublicInfoUpdate};
 pub use settings::Settings;

--- a/lttcore/src/examples/tic_tac_toe/mod.rs
+++ b/lttcore/src/examples/tic_tac_toe/mod.rs
@@ -1,12 +1,12 @@
 mod action;
-mod board;
+pub mod board;
 pub mod helpers;
 mod marker;
 mod public_info;
 mod settings;
 
 pub use action::{Action, ActionError};
-pub use board::{BoardIndex, Col, Position, Row, POSSIBLE_WINS};
+pub use board::{Board, BoardIndex, Col, Position, Row, Status, POSSIBLE_WINS};
 pub use marker::Marker;
 pub use public_info::{PublicInfo, PublicInfoUpdate};
 pub use settings::Settings;
@@ -14,43 +14,24 @@ pub use settings::Settings;
 use crate::play::view::NoSecretPlayerInfo;
 use crate::{
     play::{ActionResponse, DebugMsgs, GameAdvance},
-    utilities::number_of_players::TWO_PLAYER,
-    NumberOfPlayers, Play, Player, PlayerSet,
+    Play, Player, PlayerSet,
 };
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
-use std::collections::HashMap;
-
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub enum Status {
-    /// There are still available positions to be claimed on the board
-    InProgress { next_up: Player },
-    /// All positions have been claimed and there is no winner
-    Draw,
-    /// Win by resignation
-    WinByResignation { winner: Player },
-    /// There *is* a winner via connecting three spaces
-    Win {
-        winner: Player,
-        positions: [Position; 3],
-    },
-}
-
-impl Status {
-    pub fn winner(&self) -> Option<Player> {
-        match self {
-            Status::Win { winner, .. } | Status::WinByResignation { winner, .. } => Some(*winner),
-            _ => None,
-        }
-    }
-}
-
-use Status::{Draw, InProgress, Win, WinByResignation};
 
 #[derive(Clone, Copy, Debug, Default, Hash, PartialEq, Eq, Serialize, Deserialize)]
 pub struct TicTacToe {
-    board: [[Option<Player>; 3]; 3],
-    resigned: PlayerSet,
+    board: Board,
+    resigned: Option<Marker>,
+}
+
+impl From<Board> for TicTacToe {
+    fn from(board: Board) -> Self {
+        Self {
+            board,
+            resigned: None,
+        }
+    }
 }
 
 impl TicTacToe {
@@ -61,89 +42,41 @@ impl TicTacToe {
     /// use lttcore::examples::tic_tac_toe::{TicTacToe, Status::*, Marker::*, PublicInfoUpdate::*};
     ///
     /// let mut game: TicTacToe = Default::default();
-    /// assert_eq!(game.status(), InProgress{ next_up: X.into() });
-    /// assert_eq!(game.resign(X), Resign(X.into()));
-    /// assert_eq!(game.status(), WinByResignation { winner: O.into() });
+    /// assert_eq!(game.status(), InProgress{ next_up: X });
+    /// assert_eq!(game.resign(X), Resign(X));
+    /// assert_eq!(game.status(), WinByResignation { winner: O });
     /// ```
-    pub fn resign(&mut self, player: impl Into<Player>) -> PublicInfoUpdate {
-        let player = player.into();
-        self.resigned.insert(player);
-        PublicInfoUpdate::Resign(player)
+    pub fn resign(&mut self, marker: Marker) -> PublicInfoUpdate {
+        self.resigned = Some(marker);
+        PublicInfoUpdate::Resign(marker)
     }
 
-    pub fn resigned(&self) -> &PlayerSet {
-        &self.resigned
+    pub fn resigned(&self) -> Option<Marker> {
+        self.resigned.clone()
     }
 
-    /// Returns the status of the current game
+    pub fn board(&self) -> &Board {
+        &self.board
+    }
+
+    /// Returns the status of the current game (taking into account resignation info)
+    /// see `Board::status` for more info
     /// ```
-    /// use lttcore::{Play, Player};
     /// use lttcore::ttt;
-    /// use lttcore::examples::tic_tac_toe::{TicTacToe, Row, Col, Status::*, Marker::*};
+    /// use lttcore::examples::tic_tac_toe::{TicTacToe, Status::*, Marker::*};
     ///
-    /// // In progress
-    /// let game: TicTacToe = Default::default();
-    /// assert_eq!(game.status(), InProgress{ next_up: X.into() });
-    ///
-    /// // A draw
-    /// let game: TicTacToe = ttt!([
-    ///   O X O
-    ///   X X O
-    ///   X O X
-    /// ]);
-    /// assert_eq!(game.status(), Draw);
-    ///
-    /// // If someone resigns
     /// let mut game: TicTacToe = Default::default();
     /// game.resign(X);
-    /// assert_eq!(game.status(), WinByResignation { winner: O.into() });
-    ///
-    /// // With a winning position
-    /// let game: TicTacToe = ttt!([
-    ///   - - -
-    ///   - - -
-    ///   X X X
-    /// ]);
-    ///
-    /// assert_eq!(
-    ///   game.status(),
-    ///   Win {
-    ///     winner: X.into(),
-    ///     positions: [
-    ///       (Col::new(0), Row::new(0)),
-    ///       (Col::new(0), Row::new(1)),
-    ///       (Col::new(0), Row::new(2))
-    ///     ]
-    ///   }
-    /// );
+    /// assert_eq!(game.status(), WinByResignation { winner: O });
     /// ```
     pub fn status(&self) -> Status {
-        if let Some(loser) = self.resigned().players().next() {
-            return WinByResignation {
-                winner: helpers::opponent(loser),
-            };
+        if let Some(loser) = self.resigned() {
+            Status::WinByResignation {
+                winner: loser.opponent(),
+            }
+        } else {
+            self.board().status()
         }
-
-        POSSIBLE_WINS
-            .iter()
-            .find_map(|&positions| {
-                let [a, b, c] = positions.map(|pos| self.at_position(pos));
-
-                if a == b && b == c {
-                    a.map(|winner| Win { winner, positions })
-                } else {
-                    None
-                }
-            })
-            .unwrap_or_else(|| {
-                if self.has_open_spaces() {
-                    InProgress {
-                        next_up: self.whose_turn(),
-                    }
-                } else {
-                    Draw
-                }
-            })
     }
 
     /// Claims a space for a marker, returns an error if that space is taken
@@ -154,30 +87,27 @@ impl TicTacToe {
     /// let mut game: TicTacToe = Default::default();
     /// let pos = (Col::new(0), Row::new(0));
     ///
-    /// assert_eq!(game.at_position(pos), None);
+    /// assert_eq!(game.board()[pos], None);
     /// assert!(game.claim_space(X, pos).is_ok());
-    /// assert_eq!(game.at_position(pos), Some(X.into()));
+    /// assert_eq!(game.board()[pos], Some(X.into()));
     ///
     /// // Taking an already claimed space returns an error
     /// assert_eq!(game.claim_space(O, pos), Err(SpaceIsTaken { attempted: pos }));
     /// ```
     pub fn claim_space(
         &mut self,
-        player: impl Into<Player>,
+        marker: Marker,
         position: Position,
     ) -> Result<PublicInfoUpdate, ActionError> {
-        let player = player.into();
-
-        if self.at_position(position).is_some() {
-            return Err(ActionError::SpaceIsTaken {
+        match self.board[position] {
+            None => {
+                self.board[position] = Some(marker);
+                Ok(PublicInfoUpdate::Claim(marker, position))
+            }
+            Some(_) => Err(ActionError::SpaceIsTaken {
                 attempted: position,
-            });
+            }),
         }
-
-        let (c, r) = position;
-        let (c, r): (usize, usize) = (c.into(), r.into());
-        self.board[c][r] = Some(player);
-        Ok(PublicInfoUpdate::Claim(player, position))
     }
 
     /// Claims the next available space on the board.
@@ -185,20 +115,20 @@ impl TicTacToe {
     ///
     /// ```
     /// use lttcore::ttt;
-    /// use lttcore::examples::tic_tac_toe::{Marker::*, PublicInfoUpdate::*, Col, Row};
+    /// use lttcore::examples::tic_tac_toe::{TicTacToe, Marker::*, PublicInfoUpdate::*, Col, Row};
     ///
-    /// let mut game = ttt!([
+    /// let mut game: TicTacToe = ttt!([
     ///     - - -
     ///     - - -
     ///     - - -
-    /// ]);
+    /// ]).into();
     ///
     /// let update = game.claim_next_available_space(X).unwrap();
-    /// assert_eq!(update, Claim(0.into(), (Col::new(0), Row::new(0))));
+    /// assert_eq!(update, Claim(X, (Col::new(0), Row::new(0))));
     ///
     /// assert_eq!(
-    ///   game,
-    ///   ttt!([
+    ///   game.board(),
+    ///   &ttt!([
     ///     - - -
     ///     - - -
     ///     X - -
@@ -212,286 +142,25 @@ impl TicTacToe {
     /// game.claim_next_available_space(O).unwrap();
     ///
     /// assert_eq!(
-    ///   game,
-    ///   ttt!([
-    ///     - - -
-    ///     O X O
-    ///     X O X
+    ///   game.board(),
+    ///   &ttt!([
+    ///     X O -
+    ///     O X -
+    ///     X O -
     ///   ])
     /// );
     /// ```
     pub fn claim_next_available_space(
         &mut self,
-        player: impl Into<Player>,
+        marker: Marker,
     ) -> Result<PublicInfoUpdate, ActionError> {
         let position = self
+            .board
             .empty_spaces()
             .next()
             .ok_or(ActionError::AllSpacesTaken)?;
-        self.claim_space(player, position)
-    }
 
-    /// Returns the marker at a position, since this requires [`Row`] and [`Col`] structs
-    /// the indexing will always be inbound
-    ///
-    /// ```
-    /// use lttcore::ttt;
-    /// use lttcore::examples::tic_tac_toe::{Row, Col, Marker::*};
-    ///
-    /// let game = ttt!([
-    ///   X - -
-    ///   - - -
-    ///   - X O
-    /// ]);
-    /// assert_eq!(game.at_position((Col::new(2), Row::new(0))), Some(X.into()));
-    /// assert_eq!(game.at_position((Col::new(0), Row::new(2))), Some(O.into()));
-    /// assert_eq!(game.at_position((Col::new(0), Row::new(0))), None);
-    /// ```
-    pub fn at_position(&self, (c, r): Position) -> Option<Player> {
-        let c: usize = c.into();
-        let r: usize = r.into();
-        self.board[c][r]
-    }
-
-    /// Returns a marker at a position, if the row or col is greater than 2, this returns None
-    ///
-    /// ```
-    /// use lttcore::ttt;
-    /// use lttcore::examples::tic_tac_toe::{Row, Col, Marker::*};
-    ///
-    /// let game = ttt!([
-    ///   X - -
-    ///   - - -
-    ///   - X O
-    /// ]);
-    /// assert_eq!(game.at((2, 0)), Some(X.into()));
-    /// assert_eq!(game.at((0, 2)), Some(O.into()));
-    /// assert_eq!(game.at((0, 0)), None);
-    ///
-    /// // Out of bounds numbers return None
-    /// assert_eq!(game.at((0, 1000)), None);
-    /// assert_eq!(game.at((1000, 0)), None);
-    /// ```
-    pub fn at(&self, (c, r): (usize, usize)) -> Option<Player> {
-        let col = Col::try_new(c)?;
-        let row = Row::try_new(r)?;
-
-        self.at_position((col, row))
-    }
-
-    /// Iterator over the empty spaces on the board
-    ///
-    /// ```
-    /// use lttcore::ttt;
-    /// use lttcore::examples::tic_tac_toe::{TicTacToe, Row, Col, Marker::*, Position};
-    ///
-    /// let game: TicTacToe = Default::default();
-    /// assert_eq!(game.empty_spaces().count(), 9);
-    ///
-    /// let game = ttt!([
-    ///   X X X
-    ///   X X X
-    ///   X X X
-    /// ]);
-    /// assert_eq!(game.empty_spaces().count(), 0);
-    ///
-    /// let game = ttt!([
-    ///   X O X
-    ///   - - -
-    ///   - X O
-    /// ]);
-    /// assert_eq!(game.empty_spaces().count(), 4);
-    /// assert_eq!(
-    ///   game.empty_spaces().collect::<Vec<_>>(),
-    ///   vec![
-    ///    (Col::new(0), Row::new(0)),
-    ///    (Col::new(1), Row::new(0)),
-    ///    (Col::new(1), Row::new(1)),
-    ///    (Col::new(1), Row::new(2))
-    ///   ]
-    /// );
-    /// ```
-    pub fn empty_spaces(&self) -> impl Iterator<Item = Position> + '_ {
-        self.spaces().filter_map(|(pos, player)| match player {
-            None => Some(pos),
-            Some(_) => None,
-        })
-    }
-
-    /// Iterate over the spaces on the board and the marker in the space (if there is one)
-    ///
-    /// ```
-    /// use lttcore::ttt;
-    /// use lttcore::examples::tic_tac_toe::{Row, Col, Marker::*, Position};
-    ///
-    /// let game = ttt!([
-    ///   X O X
-    ///   - - -
-    ///   - X O
-    /// ]);
-    /// assert_eq!(
-    ///   game.spaces().collect::<Vec<_>>(),
-    ///   vec![
-    ///     ((Col::new(0), Row::new(0)), None),
-    ///     ((Col::new(0), Row::new(1)), Some(X.into())),
-    ///     ((Col::new(0), Row::new(2)), Some(O.into())),
-    ///     ((Col::new(1), Row::new(0)), None),
-    ///     ((Col::new(1), Row::new(1)), None),
-    ///     ((Col::new(1), Row::new(2)), None),
-    ///     ((Col::new(2), Row::new(0)), Some(X.into())),
-    ///     ((Col::new(2), Row::new(1)), Some(O.into())),
-    ///     ((Col::new(2), Row::new(2)), Some(X.into()))
-    ///   ]
-    /// );
-    /// ```
-    pub fn spaces(&self) -> impl Iterator<Item = (Position, Option<Player>)> + '_ {
-        self.board.iter().enumerate().flat_map(|(col_num, col)| {
-            col.iter()
-                .enumerate()
-                .map(move |(row_num, &player)| ((Col::new(col_num), Row::new(row_num)), player))
-        })
-    }
-
-    /// Iterate over the spaces on the board that are taken
-    ///
-    /// ```
-    /// use lttcore::ttt;
-    /// use lttcore::examples::tic_tac_toe::{Row, Col, Marker::*};
-    ///
-    /// let game = ttt!([
-    ///   X O X
-    ///   - - -
-    ///   - X O
-    /// ]);
-    /// assert_eq!(
-    ///   game.taken_spaces().collect::<Vec<_>>(),
-    ///   vec![
-    ///     ((Col::new(0), Row::new(1)), X.into()),
-    ///     ((Col::new(0), Row::new(2)), O.into()),
-    ///     ((Col::new(2), Row::new(0)), X.into()),
-    ///     ((Col::new(2), Row::new(1)), O.into()),
-    ///     ((Col::new(2), Row::new(2)), X.into())
-    ///   ]
-    /// );
-    pub fn taken_spaces(&self) -> impl Iterator<Item = (Position, Player)> + '_ {
-        self.spaces()
-            .filter_map(|(pos, player)| player.map(|p| (pos, p)))
-    }
-
-    /// Return the marker who's turn it is
-    ///
-    /// ```
-    /// use lttcore::ttt;
-    /// use lttcore::examples::tic_tac_toe::{TicTacToe, Marker::*};
-    ///
-    /// // Starts with X
-    /// let game: TicTacToe = Default::default();
-    /// assert_eq!(game.whose_turn(), X);
-
-    /// // Once the first player goes, it's the second player's turn
-    /// let game = ttt!([
-    ///   - - -
-    ///   - - -
-    ///   X - -
-    /// ]);
-    /// assert_eq!(game.whose_turn(), O);
-
-    /// // Once O goes, it's X's turn again
-    /// let game = ttt!([
-    ///   - - -
-    ///   - - -
-    ///   X O -
-    /// ]);
-    /// assert_eq!(game.whose_turn(), X);
-
-    /// // The next player to go is always the one with the fewest spaces
-    /// let game = ttt!([
-    ///   O O O
-    ///   O O O
-    ///   - O O
-    /// ]);
-    /// assert_eq!(game.whose_turn(), X);
-    /// ```
-    pub fn whose_turn(&self) -> Player {
-        let mut counts: HashMap<Player, usize> = HashMap::new();
-
-        for (_, player) in self.taken_spaces() {
-            *counts.entry(player).or_insert(0) += 1;
-        }
-
-        TWO_PLAYER
-            .players()
-            .min_by_key(|player| counts.get(player).copied().unwrap_or(0))
-            .unwrap_or_else(NumberOfPlayers::starting_player)
-    }
-
-    /// Convenience method to construct a board from arrays of `Option<Marker>`, mostly used as the
-    /// implementation of the `ttt!` macro
-    /// ```
-    /// // An empty board
-    /// use lttcore::examples::tic_tac_toe::{TicTacToe, Col, Row, Marker::*};
-    /// let game = TicTacToe::from_markers(
-    ///   [
-    ///     [None, None, None],
-    ///     [None, None, None],
-    ///     [None, None, None]
-    ///   ]
-    /// );
-    ///
-    /// assert_eq!(game, Default::default());
-    ///
-    /// // With some things on the board
-    ///
-    /// let game = TicTacToe::from_markers(
-    ///   [
-    ///     [Some(X), None, None],
-    ///     [Some(O), Some(X), None],
-    ///     [None, None, None]
-    ///   ]
-    /// );
-    ///
-    /// assert_eq!(
-    ///   game.taken_spaces().collect::<Vec<_>>(),
-    ///   vec![
-    ///     ((Col::new(0), Row::new(0)), X.into()),
-    ///     ((Col::new(1), Row::new(0)), O.into()),
-    ///     ((Col::new(1), Row::new(1)), X.into())
-    ///   ]
-    /// )
-    /// ```
-    pub fn from_markers(board: [[Option<Marker>; 3]; 3]) -> Self {
-        let board = board.map(|col| col.map(|opt_marker| opt_marker.map(|marker| marker.into())));
-
-        Self {
-            board,
-            ..Default::default()
-        }
-    }
-
-    /// is the board full?
-    ///
-    /// ```
-    /// use lttcore::ttt;
-    ///
-    /// let game = ttt!([
-    ///   X X X
-    ///   X - X
-    ///   X X X
-    /// ]);
-    ///
-    /// assert!(game.has_open_spaces());
-    ///
-    /// let game = ttt!([
-    ///   X X X
-    ///   X X X
-    ///   X X X
-    /// ]);
-    ///
-    /// assert!(!game.has_open_spaces());
-    ///
-    /// ```
-    pub fn has_open_spaces(&self) -> bool {
-        self.taken_spaces().count() < 9
+        self.claim_space(marker, position)
     }
 }
 
@@ -504,13 +173,13 @@ impl Play for TicTacToe {
 
     fn which_players_input_needed(&self, _settings: &Self::Settings) -> PlayerSet {
         match self.status() {
-            Status::InProgress { next_up } => next_up.into(),
+            Status::InProgress { next_up } => Player::from(next_up).into(),
             _ => Default::default(),
         }
     }
 
     fn public_info(&self, _settings: &Self::Settings) -> Cow<'_, Self::PublicInfo> {
-        Cow::Owned(PublicInfo::from_ttt(*self))
+        Cow::Owned(PublicInfo::from(*self))
     }
 
     fn initial_state_for_settings(
@@ -540,20 +209,22 @@ impl Play for TicTacToe {
             .next()
             .expect("Tic Tac Toe is single player at a time");
 
+        let marker = Marker::try_from(player).expect("only p0 or p1 was passed");
+
         let mut debug_msgs: DebugMsgs<Self> = Default::default();
 
         let public_info_update = {
             match response.as_ref() {
-                Resign => self.resign(player),
+                Resign => self.resign(marker),
                 Timeout => self
-                    .claim_next_available_space(player)
+                    .claim_next_available_space(marker)
                     .expect("Tried to apply an action to a full board"),
 
-                Response(Action { position }) => match self.claim_space(player, *position) {
+                Response(Action { position }) => match self.claim_space(marker, *position) {
                     Ok(update) => update,
                     Err(err) => {
                         debug_msgs.insert(player, err);
-                        self.claim_next_available_space(player)
+                        self.claim_next_available_space(marker)
                             .expect("Tried to apply an action to a full board")
                     }
                 },

--- a/lttcore/tests/tic_tac_toe_serialization.rs
+++ b/lttcore/tests/tic_tac_toe_serialization.rs
@@ -30,22 +30,15 @@ fn test_serde_action_and_error() {
 
 #[test]
 fn test_serde_ttt() {
-    let game = ttt!([
+    let board = ttt!([
       - - -
       O X O
       X X X
     ]);
 
     test_simple_serialization(
-        &game,
-        json!({
-            "resigned": [0, 0, 0, 0],
-            "board": [
-                [0, 0, 0],
-                [1, 0, 1],
-                [Null, Null, Null]
-            ]
-        }),
+        &board,
+        json!([["X", "X", "X"], ["O", "X", "O"], [Null, Null, Null]]),
     );
 }
 


### PR DESCRIPTION
## Make TicTacToe more user friendly to work with

The idea here is that the bot writer will mainly interact with the
`Board` struct from the `TicTacToeBot::claim_space` method. This allows
`lttcore` to hide all the mess around `Play::{Action/Player/etc..}`