### PR TITLE
Make the `Bot::run` interface take a `&mut self`

### DIFF
--- a/lttcore/src/bot/defective.rs
+++ b/lttcore/src/bot/defective.rs
@@ -13,7 +13,7 @@ macro_rules! panicking_bot {
                 type Game = $game;
 
                 fn run(
-                    &self,
+                    &mut self,
                     _pov: &$crate::pov::player::PlayerPov<'_, Self::Game>,
                     _seed: &$crate::play::Seed
                     ) -> <Self::Game as $crate::play::Play>::Action {

--- a/lttcore/src/bot/mod.rs
+++ b/lttcore/src/bot/mod.rs
@@ -1,20 +1,68 @@
 //! Traits for working with bots
+#![allow(missing_docs)]
 
-use crate::play::{Play, Seed};
+use bytes::Bytes;
+use serde::Serialize;
+use crate::{play::{Play, Seed}, encoding::Encoding};
 use crate::pov::player::PlayerPov;
-use std::panic::RefUnwindSafe;
+use std::borrow::Cow;
+use std::sync::Arc;
 
 pub(crate) mod defective;
 
 /// Trait to interact with [`Play`] compatible games as a [`Player`](crate::play::Player)
-pub trait Bot: RefUnwindSafe + Sync + Send + 'static {
+pub trait Bot: Sync + Send + 'static {
     /// The [`Play`] compatible game that this bot understands
     type Game: Play;
 
     /// Callback for when it's the bot's [`Player`](crate::play::Player)'s turn to take an action
     fn run(
-        &self,
+        &mut self,
         player_pov: &PlayerPov<'_, Self::Game>,
         rng: &Seed,
     ) -> <Self::Game as Play>::Action;
+}
+
+pub trait DumpState {
+    fn dump_state(&self, encoding: Encoding) -> Bytes; 
+}
+
+/// A trait saying that the implemeter can make an instance of a [`Bot`]
+pub trait MakeBotInstance<T: Play>: Send + Sync + 'static {
+    fn make_bot_instance(&self) -> Box<dyn Bot<Game = T>>;
+}
+
+#[allow(missing_debug_implementations)]
+#[derive(Clone)]
+pub struct Contender<T: Play> {
+    name: Cow<'static, str>,
+    bot: Arc<dyn MakeBotInstance<T>>,
+}
+
+impl<T: Play, B: Bot<Game=T> + Serialize> DumpState for B {
+    fn dump_state(&self, encoding: Encoding) -> Bytes {
+        encoding.serialize(&self).expect("you can serialize the state of the bot")
+    }
+}
+
+impl<T: Play> Contender<T> {
+    pub fn new(name: impl Into<Cow<'static, str>>, bot: impl MakeBotInstance<T>) -> Self {
+        Self {
+            name: name.into(),
+            bot: Arc::new(bot),
+        }
+    }
+
+    pub fn name(&self) -> &str {
+        self.name.as_ref()
+    }
+    pub fn make_bot_instance(&self) -> Box<dyn Bot<Game = T>> {
+        self.bot.make_bot_instance()
+    }
+}
+
+impl<T: Play, B: Bot<Game = T> + Clone> MakeBotInstance<T> for B {
+    fn make_bot_instance(&self) -> Box<dyn Bot<Game = T>> {
+        Box::new(self.clone())
+    }
 }

--- a/lttcore/src/examples/tic_tac_toe/bot/mod.rs
+++ b/lttcore/src/examples/tic_tac_toe/bot/mod.rs
@@ -7,7 +7,7 @@ use super::{Action, Board, Position, TicTacToe};
 use crate::bot::Bot;
 use crate::play::{Play, Seed};
 use crate::pov::player::PlayerPov;
-use std::panic::RefUnwindSafe;
+use std::fmt::Debug;
 
 /// A simplified [`Bot`](`crate::bot::Bot`) wrapper specialized for playing [`TicTacToe`]
 pub trait TicTacToeBot {
@@ -18,14 +18,14 @@ pub trait TicTacToeBot {
 }
 
 /// Wrapper type to implement [`Bot`](`crate::bot::Bot`) for any [`TicTacToeBot`]
-#[derive(Debug)]
-pub struct TicTacToeBotWrapper<T: TicTacToeBot + RefUnwindSafe + Sync + Send + 'static>(pub T);
+#[derive(Debug, Clone)]
+pub struct TicTacToeBotWrapper<T: TicTacToeBot + Debug + Clone + Sync + Send + 'static>(pub T);
 
-impl<T: TicTacToeBot + RefUnwindSafe + Sync + Send + 'static> Bot for TicTacToeBotWrapper<T> {
+impl<T: TicTacToeBot + Debug + Clone + Sync + Send + 'static> Bot for TicTacToeBotWrapper<T> {
     type Game = TicTacToe;
 
     fn run(
-        &self,
+        &mut self,
         player_pov: &PlayerPov<'_, Self::Game>,
         seed: &Seed,
     ) -> <Self::Game as Play>::Action {

--- a/lttstadium/src/bin.rs
+++ b/lttstadium/src/bin.rs
@@ -1,4 +1,5 @@
 use lttcore::{
+    bot::Contender,
     examples::{
         tic_tac_toe::{
             bot::prebuilt::{Expert, Intermediate},
@@ -8,7 +9,7 @@ use lttcore::{
     },
     play::Player,
 };
-use lttstadium::{Contender, FightCard, FightCardBuilder};
+use lttstadium::{FightCard, FightCardBuilder};
 
 fn main() {
     let bots = vec![


### PR DESCRIPTION
# Update: Closed in favor of https://github.com/GrantJamesPowell/lib_table_top/pull/84

Still feel a little uneasy about this one.

I think it's really important to be able to use information from earlier
in the game in order to affect what your bot does this turn, but the
question is how do we want to provide that data to the bot.

It seems weird for the bot to need to keep track of the history of the
game when `ltt` provides state machines for all the major components of
the game, but it seems weird for things like `GamePlayer` to be in
charge in providing views into historical data, _especially_ if a bot
decides it doesn't need that info.

Then comes the question is there a generic thing that a bot could do to
"opt in" to history, even if we just provide a container to store it's
updates in. It also means we likely need callbacks even when the bot
isn't called to act, passing the update itself into the bot so it can
change it's state based on the data it just got. The whole thing feels
pretty weird and I need to think on it more

